### PR TITLE
Delete now useless directory with dummy file

### DIFF
--- a/Source/PCH/nopch/pch.h
+++ b/Source/PCH/nopch/pch.h
@@ -1,4 +1,0 @@
-// dummy include to help with disabling pch for a single file
-// cmake doesn't provide a clean way to disable MSVC's force include option
-
-// So we can just point it at an empty file instead.


### PR DESCRIPTION
This was made as a workaround for having PCH ignore the file `ImageC.c` which could not be made into `.cpp` due to limitations of libpng, but since it has been replaced by libspng #10889 this is no longer needed.